### PR TITLE
fix: infinite loop

### DIFF
--- a/svg-time-series/src/chart/eventEmitter.test.ts
+++ b/svg-time-series/src/chart/eventEmitter.test.ts
@@ -73,6 +73,7 @@ describe("TimeSeriesChart event emitter", () => {
 
     const brushEvent = {
       selection: [0, 100],
+      sourceEvent: {},
     } as unknown as D3BrushEvent<unknown>;
     (
       chart as unknown as { onBrushEnd: (e: D3BrushEvent<unknown>) => void }

--- a/svg-time-series/src/chart/interaction.resetZoom.test.ts
+++ b/svg-time-series/src/chart/interaction.resetZoom.test.ts
@@ -227,6 +227,7 @@ describe("interaction.enableBrush", () => {
     ) => x;
     internal.onBrushEnd({
       selection: [0, 10],
+      sourceEvent: {},
     } as unknown as D3BrushEvent<unknown>);
     expect(interaction.getSelectedTimeWindow()).not.toBeNull();
 
@@ -261,6 +262,7 @@ describe("interaction.disableBrush", () => {
     ) => x;
     internal.onBrushEnd({
       selection: [0, 10],
+      sourceEvent: {},
     } as unknown as D3BrushEvent<unknown>);
     expect(interaction.getSelectedTimeWindow()).not.toBeNull();
     interaction.disableBrush();

--- a/svg-time-series/src/draw.test.ts
+++ b/svg-time-series/src/draw.test.ts
@@ -294,6 +294,7 @@ describe("TimeSeriesChart", () => {
 
     internal.onBrushEnd({
       selection: [0, 10],
+      sourceEvent: {},
     } as unknown as D3BrushEvent<unknown>);
 
     expect(transformSpy).not.toHaveBeenCalled();

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -383,6 +383,9 @@ export class TimeSeriesChart {
   }
 
   private onBrushEnd = (event: D3BrushEvent<unknown>) => {
+    // Ignore programmatic brush clears to avoid infinite recursion
+    if (!event.sourceEvent) return;
+
     const timeWindow = handleBrushEnd(
       event,
       this.data,


### PR DESCRIPTION
When `brush.move()` is called programmatically, the event has no `sourceEvent` (it's only present for user-initiated events). By checking `if (!event.sourceEvent) return;`, we skip the handler when it's triggered by our own `clearBrushSelection` call, breaking the infinite loop.