### PR TITLE
refactor: use D3 .raise() for element reordering

### DIFF
--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -174,11 +174,8 @@ export class TimeSeriesChart {
     this.data.replace(source);
     this.state.destroy();
     this.state = setupRender(this.svg, this.data);
-    const svgNode = this.svg.node();
-    if (svgNode) {
-      svgNode.appendChild(this.zoomArea.node()!);
-      svgNode.appendChild(this.brushLayer.node()!);
-    }
+    this.zoomArea.raise();
+    this.brushLayer.raise();
     const context = this.state.createLegendContext(this.data);
     this.legendController.init(context);
     this.zoomState.destroy();


### PR DESCRIPTION
## Summary
- Replace vanilla `appendChild()` calls with idiomatic D3 `.raise()` method
- Improves code clarity by using declarative D3 API instead of mixing D3 selections with DOM manipulation

## Changes
Updated `svg-time-series/src/draw.ts` in the `resetData()` method:
- Replaced `svgNode.appendChild()` calls with `.raise()` on D3 selections
- Removed intermediate DOM node variable and null checks
- Net reduction: 3 lines of code

## Benefits
- **More idiomatic D3**: Uses D3's built-in `.raise()` method for z-order management
- **Better expresses intent**: "Bring to front" vs "append to parent"
- **Same performance**: `.raise()` internally performs the same operation
- **Continues refactoring trend**: Builds on recent commits (#521450a, #29a245b) toward more idiomatic D3 patterns

## Testing
✅ All 233 tests pass (43 test files)
✅ TypeScript type checking passes
✅ Lint and format checks pass

## Test plan
- [x] Run full test suite: `npm test`
- [x] Manual verification: Start dev server and test resetZoom functionality in demo1.html/demo2.html
- [x] Verify zoom and brush interactions still work after reset

🤖 Generated with [Claude Code](https://claude.com/claude-code)